### PR TITLE
Add dependency on node-fetch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var fetch = require("node-fetch");
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/package.json
+++ b/package.json
@@ -50,5 +50,7 @@
       "lib"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "node-fetch": "^1.6.3"
+  }
 }


### PR DESCRIPTION
As it is, `coinmarketcap.ticker()` fails with `fetch is not a function` if you try to use this in a Node.js app.